### PR TITLE
do not log every time lookup module is loaded (#687)

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -2600,8 +2600,7 @@ class Notifications(object):
                     resp.status = HTTP_200
                     return
             logger.error("failed posting notification via external sender: %s", r.text)
-            resp.status = HTTP_503
-            return
+            raise HTTPBadRequest(r.text)
 
         # If we're using ZK, try that to get leader
         if self.coordinator:
@@ -5819,6 +5818,9 @@ class InternalBuildMessages():
             logger.warning('Failed to build due to missing application key')
             raise HTTPBadRequest('INVALID application')
 
+        if notification.get('role') == 'literal_target':
+            notification['unexpanded'] = True
+
         if "incident_id" in notification and "dynamic_index" in notification:
             # check if plan is dynamic and retrieve role & target for incident
             conn = db.engine.raw_connection()
@@ -5839,19 +5841,16 @@ class InternalBuildMessages():
             cursor.close()
             conn.close()
 
-        notification['subject'] = '[%s] %s' % (notification['application'],
-                                               notification.get('subject', ''))
+        notification['subject'] = '[%s] %s' % (notification['application'], notification.get('subject', ''))
         target_list = notification.get('target_list')
         role = notification.get('role')
         if not role and not target_list:
-            logger.warning('Failed to build message with invalid role "%s" from app %s',
-                           role, notification['application'])
+            logger.warning('Failed to build message with invalid role "%s" from app %s', role, notification['application'])
             raise HTTPBadRequest('INVALID role')
 
         target = notification.get('target')
         if not (target or target_list):
-            logger.warning('Failed to build message with invalid target "%s" from app %s',
-                           target, notification['application'])
+            logger.warning('Failed to build message with invalid target "%s" from app %s', target, notification['application'])
             raise HTTPBadRequest('INVALID target')
         expanded_targets = None
         # if role is literal_target skip unrolling
@@ -5886,8 +5885,7 @@ class InternalBuildMessages():
                 except IrisRoleLookupException:
                     expanded_targets = None
             if not expanded_targets and not has_literal_target:
-                logger.warning('Failed to build with invalid role:target "%s:%s" from app %s',
-                               role, target, notification['application'])
+                logger.warning('Failed to build with invalid role:target "%s:%s" from app %s', role, target, notification['application'])
                 raise HTTPBadRequest('INVALID role:target')
 
         sanitize_unicode_dict(notification)
@@ -5896,16 +5894,14 @@ class InternalBuildMessages():
         # needed iris key.
         if 'template' in notification:
             if 'context' not in notification:
-                logger.warning('Failed to build due to missing context from app %s',
-                               notification['application'])
+                logger.warning('Failed to build due to missing context from app %s', notification['application'])
                 raise HTTPBadRequest('INVALID context')
             else:
                 # fill in dummy iris meta data
                 notification['context']['iris'] = {}
         elif 'email_html' in notification:
             if not isinstance(notification['email_html'], str):
-                logger.warning('Failed to build with invalid email_html from app %s: %s',
-                               notification['application'], notification['email_html'])
+                logger.warning('Failed to build with invalid email_html from app %s: %s', notification['application'], notification['email_html'])
                 raise HTTPBadRequest('INVALID email_html')
 
         notifications = []
@@ -5931,8 +5927,11 @@ class InternalBuildMessages():
             if not success:
                 logger.warning('Failed to build, could not resolve target contacts %s' % ujson.dumps(notification))
                 continue
-            message = render(message)
-            messages.append(message)
+            try:
+                message = render(message)
+                messages.append(message)
+            except Exception as e:
+                logger.warning('Failed to render message %s with error: %s' % (ujson.dumps(notification), str(e)))
         if len(messages) == 0:
             raise HTTPBadRequest('Failed to build, could not resolve any messages from notification')
 

--- a/src/iris/role_lookup/__init__.py
+++ b/src/iris/role_lookup/__init__.py
@@ -22,7 +22,7 @@ def get_role_lookups(config):
         try:
             imported_modules.append(
                 import_custom_module('iris.role_lookup', m)(config))
-            logger.info('Loaded lookup modules: %s', m)
+            logger.debug('Loaded lookup modules: %s', m)
         except Exception:
             logger.exception('Failed to load role lookup module: %s', m)
 


### PR DESCRIPTION
* do not load configs from util

* create external_sender_incident_dryrun category

* remove comment

* restore auth req

* fail build_message reqs when no messages made

* revert oncall metrics change

* check oncall_error is defined in stats

* change key check syntax

* create ca_bundle_path config

* do not log every time lookup module is loaded

* make module log level debug

* change failed notification status code

* flake8